### PR TITLE
Copy-to-clipboard-fixes

### DIFF
--- a/docs/src/script.js
+++ b/docs/src/script.js
@@ -129,62 +129,6 @@ listenEvents = () => {
 
 
 /**
- * Share page by using the share api
- * 
- * @async
- * @function sharePage
- * @throws {error} When the share api isn't available or the share fails
- * 
- */
-sharePage = async () => {
-
-  if (navigator.share) {
-    try {
-      await navigator.share(shareData);
-      console.log('Shared successfully');
-    } catch (err) {
-      console.log(`Error: ${err}`);
-    }
-  } else {
-      copyUrl();
-  }
-  
-};
-
-
-/**
- * Copy URL to clipboard
- * 
- * @function copyUrl
- * @returns {void}
- * 
- */
-copyUrl = () => {
-
-  // Handle URL
-  const textArea = document.createElement('textarea');
-  textArea.value = shareData.url;
-  document.body.appendChild(textArea);
-  textArea.select();
-
-  // Copy or throw an error
-  try {
-    document.execCommand('copy');
-    alert(
-      'Das Teilen über die Share-API wird in diesem Browser aktuell noch nicht unterstützt. ✖️\n' +
-      'Die URL der Projektseite wurde daher zum Teilen in die Zwischenablage kopiert. ✔️'
-    );
-  } catch (err) {
-    console.error('Fehler beim Kopieren in die Zwischenablage: ', err);
-  }
-
-  // Entfernen Sie das Textfeld aus dem Dokument
-  document.body.removeChild(textArea);
-  
-};
-
-
-/**
  * Get images values
  * 
  * @function getValues
@@ -371,6 +315,62 @@ scrollResult = () => {
     behavior: 'smooth'
   });
 
+};
+
+
+/**
+ * Share page by using the share api
+ * 
+ * @async
+ * @function sharePage
+ * @throws {error} When the share api isn't available or the share fails
+ * 
+ */
+sharePage = async () => {
+
+  if (navigator.share) {
+    try {
+      await navigator.share(shareData);
+      console.log('Shared successfully');
+    } catch (err) {
+      console.log(`Error: ${err}`);
+    }
+  } else {
+      copyUrl();
+  }
+  
+};
+
+
+/**
+ * Copy URL to clipboard
+ * 
+ * @function copyUrl
+ * @returns {void}
+ * 
+ */
+copyUrl = () => {
+
+  // Handle URL
+  const textArea = document.createElement('textarea');
+  textArea.value = shareData.url;
+  document.body.appendChild(textArea);
+  textArea.select();
+
+  // Copy or throw an error
+  try {
+    document.execCommand('copy');
+    alert(
+      'Das Teilen über die Share-API wird in diesem Browser aktuell noch nicht unterstützt. ✖️\n' +
+      'Die URL der Projektseite wurde daher zum Teilen in die Zwischenablage kopiert. ✔️'
+    );
+  } catch (err) {
+    console.error('Fehler beim Kopieren in die Zwischenablage: ', err);
+  }
+
+  // Entfernen Sie das Textfeld aus dem Dokument
+  document.body.removeChild(textArea);
+  
 };
 
 

--- a/docs/src/script.js
+++ b/docs/src/script.js
@@ -383,13 +383,34 @@ scrollResult = () => {
  */
 copyClipboard = () => {
 
-  // Copy content
-  document.getElementById('imagescene-result').select();
-  document.execCommand('copy');
+  let textToCopy = document.getElementById('imagescene-result').value;
 
-  // Call infobox
-  let content = 'In die Zwischenablage kopiert ✔';
-  showInfo(content);
+  if ('clipboard' in navigator) {
+    navigator.clipboard.writeText(textToCopy)
+      .then(() => {
+        // Success
+        let content = 'In die Zwischenablage kopiert ✔';
+        showInfo(content);
+      })
+      .catch(err => {
+        // Error
+        console.error('copy to clipboard error: ', err);
+        let content = 'Fehler beim Kopieren in die Zwischenablage ✖️';
+        showInfo(content);
+      });
+  } else {
+    // Fallback for older browsers
+    const textArea = document.createElement('textarea');
+    textArea.value = textToCopy;
+    document.body.appendChild(textArea);
+    textArea.select();
+    document.execCommand('copy');
+    document.body.removeChild(textArea);
+
+    // Call infobox
+    let content = 'In die Zwischenablage kopiert ✔';
+    showInfo(content);
+  }
 
 };
 

--- a/docs/src/script.js
+++ b/docs/src/script.js
@@ -484,10 +484,6 @@ handleFileSelect = (file) => {
         let textarea = document.getElementById('imagescene-url');
         textarea.value = dataUri;
         
-        console.log('Breite: ' + originalWidth + 'px');
-        console.log('Höhe: ' + originalHeight + 'px');
-        console.log('Data URI des ausgewählten Bildes:', dataUri);
-        
       };
 
     };

--- a/docs/src/script.js
+++ b/docs/src/script.js
@@ -347,38 +347,6 @@ sharePage = async () => {
 
 
 /**
- * Copy URL to clipboard
- * 
- * @function copyUrl
- * @returns {void}
- * 
- */
-copyUrl = () => {
-
-  // Handle URL
-  const textArea = document.createElement('textarea');
-  textArea.value = shareData.url;
-  document.body.appendChild(textArea);
-  textArea.select();
-
-  // Copy or throw an error
-  try {
-    document.execCommand('copy');
-    alert(
-      'Das Teilen über die Share-API wird in diesem Browser aktuell noch nicht unterstützt. ✖️\n' +
-      'Die URL der Projektseite wurde daher zum Teilen in die Zwischenablage kopiert. ✔️'
-    );
-  } catch (err) {
-    console.error('Fehler beim Kopieren in die Zwischenablage: ', err);
-  }
-
-  // Entfernen Sie das Textfeld aus dem Dokument
-  document.body.removeChild(textArea);
-  
-};
-
-
-/**
  * Copy to clipboard
  * 
  * @function copyClipboard

--- a/docs/src/script.js
+++ b/docs/src/script.js
@@ -336,7 +336,11 @@ sharePage = async () => {
       console.log(`Error: ${err}`);
     }
   } else {
-      copyUrl();
+    alert(
+      'Das Teilen über die Share-API wird in diesem Browser aktuell noch nicht unterstützt. ✖️\n' +
+      'Die URL der Projektseite wird daher zum Teilen in die Zwischenablage kopiert. ✔️'
+    );
+    copyClipboard('share');
   }
   
 };
@@ -378,12 +382,14 @@ copyUrl = () => {
  * Copy to clipboard
  * 
  * @function copyClipboard
+ * @param {string} target - Content to copy
  * @returns {void}
  *
  */
-copyClipboard = () => {
+copyClipboard = (target) => {
 
-  let textToCopy = document.getElementById('imagescene-result').value;
+  // Check if the url for sharing or the result should be copied to clipboard
+  let textToCopy = target === 'share' ? shareData.url : document.getElementById('imagescene-result').value;
 
   if ('clipboard' in navigator) {
     navigator.clipboard.writeText(textToCopy)


### PR DESCRIPTION
Handle clipboard functionalities:

- include navigator.clipboard
- set execCommand as fallback
- implement another fallback by printing a message
- remove function for copying url and include parts to the clipboard function
- revise information texts
- clean code

closes #3